### PR TITLE
Fixed dependency order in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,8 +17,8 @@
   ],
   "dependencies": {
     "angular": "^1.4.0",
-    "rickshaw": "~1.5.1",
-    "d3": "~3.5.5"
+    "d3": "~3.5.5",
+    "rickshaw": "~1.5.1"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
this dependecy order was causing loading error if using wiredep

```
rickshaw.js:9 Uncaught ReferenceError: d3 is not defined(anonymous function) @ rickshaw.js:9(anonymous function) @ rickshaw.js:11
```

rickshaw was being loaded before d3