### PR TITLE
Rickshaw compatibility bower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /bower_components/
 /node_modules/
+.idea
+

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "angular": "^1.4.0",
     "d3": "~3.5.5",
-    "rickshaw": "~1.5.1"
+    "rickshaw": "^1.5.1"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Rickshaw 1.6.0 has been released recently . This directive works with the same as well. Hence upgrading the dependency chart accordingly. 